### PR TITLE
Fixed typo on Chapter 1 practice questions (added end quotes on "apple")

### DIFF
--- a/chapter01_introduction/practice_questions.ipynb
+++ b/chapter01_introduction/practice_questions.ipynb
@@ -77,7 +77,7 @@
     "5. What do we need to do to, and to which variable, before we can concatenate the two values?\n",
     "6. What do we need to do to, and to which variable, before we can *sum* the two values?\n",
     "7. For each of the following, can we cast it to a string? \n",
-    " * \"apple\n",
+    " * \"apple\"\n",
     " * \"4.5\"\n",
     " * 9.2\n",
     " * 11\n",
@@ -135,7 +135,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This was just a small typo fix to add an end quote to "apple" under "Casting" question 7.

I used this small fix to learn about creating forks, adding branches, and making pull requests.

I'm not sure about that Python version change that also shows up as an addition and deletion. Is that because I have a different version of Python3 on my local machine than yours, and does it matter?